### PR TITLE
Fix crypto.h's header guard

### DIFF
--- a/crypto.h
+++ b/crypto.h
@@ -3,7 +3,7 @@
 // Last Update: Aug 8, 2005
 // Author: Jinliang Fan, David Stott (stott@lucent.com)
 
-#ifndef CRYTPO_H
+#ifndef CRYPTO_H
 #define CRYPTO_H
 
 #include <sys/types.h>


### PR DESCRIPTION
Fixes the following clang warning:

cryptopanlib/crypto.h:6:9: warning: 'CRYTPO_H' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
#ifndef CRYTPO_H
        ^~~~~~~~
cryptopanlib/crypto.h:7:9: note: 'CRYPTO_H' is defined here; did you mean 'CRYTPO_H'?
#define CRYPTO_H
        ^~~~~~~~
        CRYTPO_H
1 warning generated.